### PR TITLE
Pass message metadata through SQS MessageAttributes.

### DIFF
--- a/sqs/marshaler.go
+++ b/sqs/marshaler.go
@@ -19,15 +19,65 @@ type DefaultMarshalerUnmarshaler struct{}
 
 func (d DefaultMarshalerUnmarshaler) Marshal(msg *message.Message) (*sqs.Message, error) {
 	return &sqs.Message{
-		Body:      aws.String(string(msg.Payload)),
-		MessageId: aws.String(msg.UUID),
+		MessageAttributes: metadataToAttributes(msg.Metadata),
+		Body:              aws.String(string(msg.Payload)),
+		MessageId:         aws.String(msg.UUID),
 	}, nil
 }
 
 func (d DefaultMarshalerUnmarshaler) Unmarshal(msg *sqs.Message) (*message.Message, error) {
-	// TODO nil check
-	uuid := *msg.MessageId
-	payload := *msg.Body
+	var uuid, payload string
 
-	return message.NewMessage(uuid, []byte(payload)), nil
+	if msg.MessageId != nil {
+		uuid = *msg.MessageId
+	}
+
+	if msg.Body != nil {
+		payload = *msg.Body
+	}
+
+	wmsg := message.NewMessage(uuid, []byte(payload))
+	wmsg.Metadata = attributesToMetadata(msg.MessageAttributes)
+
+	return wmsg, nil
 }
+
+func metadataToAttributes(meta message.Metadata) map[string]*sqs.MessageAttributeValue {
+	attributes := make(map[string]*sqs.MessageAttributeValue)
+
+	for k, v := range meta {
+		attributes[k] = &sqs.MessageAttributeValue{
+			StringValue: aws.String(v),
+			DataType:    aws.String(AWSStringDataType),
+		}
+	}
+
+	return attributes
+}
+
+func attributesToMetadata(attributes map[string]*sqs.MessageAttributeValue) message.Metadata {
+	meta := make(message.Metadata)
+
+	for k, v := range attributes {
+		if v.DataType == nil {
+			continue
+		}
+
+		switch *v.DataType {
+		case AWSStringDataType, AWSNumberDataType:
+			if v.StringValue != nil {
+				meta[k] = *v.StringValue
+			}
+		case AWSBinaryDataType:
+			meta[k] = string(v.BinaryValue)
+		}
+	}
+
+	return meta
+}
+
+const (
+	AWSStringDataType = "String"
+	AWSNumberDataType = "Number"
+	AWSBinaryDataType = "Binary"
+)

--- a/sqs/marshaler_test.go
+++ b/sqs/marshaler_test.go
@@ -1,0 +1,39 @@
+package sqs
+
+import (
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadaConverter(t *testing.T) {
+	metadata := message.Metadata{
+		"name": "some-event-name",
+		"test": "other-value",
+	}
+
+	metadataOut := attributesToMetadata(metadataToAttributes(metadata))
+
+	require.Equal(t, metadata, metadataOut, "metadata after transformations should be the same")
+}
+
+func TestMarshaler(t *testing.T) {
+	msg := message.NewMessage("some-id", []byte("payload"))
+	msg.Metadata = message.Metadata{
+		"name": "some-event-name",
+		"test": "other-value",
+	}
+
+	dum := &DefaultMarshalerUnmarshaler{}
+
+	awsMsg, err := dum.Marshal(msg)
+	require.NoError(t, err)
+
+	msgOut, err := dum.Unmarshal(awsMsg)
+	require.NoError(t, err)
+
+	require.Equal(t, msg.UUID, msgOut.UUID)
+	require.Equal(t, msg.Payload, msgOut.Payload)
+	require.Equal(t, msg.Metadata, msgOut.Metadata)
+}

--- a/sqs/subscriber.go
+++ b/sqs/subscriber.go
@@ -71,6 +71,9 @@ func (s Subscriber) receive(ctx context.Context, queueURL string, output chan *m
 	result, err := s.sqs.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 		WaitTimeSeconds: aws.Int64(1),
 		QueueUrl:        aws.String(queueURL),
+		MessageAttributeNames: []*string{
+			aws.String(sqs.QueueAttributeNameAll),
+		},
 	})
 	if err != nil {
 		return err
@@ -109,7 +112,6 @@ func (s Subscriber) deleteMessage(ctx context.Context, queueURL string, receiptH
 		QueueUrl:      aws.String(queueURL),
 		ReceiptHandle: receiptHandle,
 	})
-
 	if err != nil {
 		// TODO wrap
 		return err


### PR DESCRIPTION
This PR allows passing the name of the event through SQS MessageAttributes so SQS publisher/subscriber can be used with CQRS setup.