### PR TITLE
fix(sqs): UUID lost via marshalling

### DIFF
--- a/sqs/marshaler.go
+++ b/sqs/marshaler.go
@@ -15,65 +15,60 @@ type UnMarshaler interface {
 	Unmarshal(msg *sqs.Message) (*message.Message, error)
 }
 
+// UUIDHeaderKey is the key of the Pub/Sub attribute that carries Waterfall UUID.
+const UUIDHeaderKey = "_watermill_message_uuid"
+
 type DefaultMarshalerUnmarshaler struct{}
 
 func (d DefaultMarshalerUnmarshaler) Marshal(msg *message.Message) (*sqs.Message, error) {
-	return &sqs.Message{
-		MessageAttributes: metadataToAttributes(msg.Metadata),
-		Body:              aws.String(string(msg.Payload)),
-		MessageId:         aws.String(msg.UUID),
-	}, nil
-}
-
-func (d DefaultMarshalerUnmarshaler) Unmarshal(msg *sqs.Message) (*message.Message, error) {
-	var uuid, payload string
-
-	if msg.MessageId != nil {
-		uuid = *msg.MessageId
-	}
-
-	if msg.Body != nil {
-		payload = *msg.Body
-	}
-
-	wmsg := message.NewMessage(uuid, []byte(payload))
-	wmsg.Metadata = attributesToMetadata(msg.MessageAttributes)
-
-	return wmsg, nil
-}
-
-func metadataToAttributes(meta message.Metadata) map[string]*sqs.MessageAttributeValue {
-	attributes := make(map[string]*sqs.MessageAttributeValue)
-
-	for k, v := range meta {
+	attributes := make(map[string]*sqs.MessageAttributeValue, len(msg.Metadata)+1)
+	for k, v := range msg.Metadata {
 		attributes[k] = &sqs.MessageAttributeValue{
 			StringValue: aws.String(v),
 			DataType:    aws.String(AWSStringDataType),
 		}
 	}
+	attributes[UUIDHeaderKey] = &sqs.MessageAttributeValue{
+		StringValue: aws.String(msg.UUID),
+		DataType:    aws.String(AWSStringDataType),
+	}
 
-	return attributes
+	return &sqs.Message{
+		MessageAttributes: attributes,
+		Body:              aws.String(string(msg.Payload)),
+	}, nil
 }
 
-func attributesToMetadata(attributes map[string]*sqs.MessageAttributeValue) message.Metadata {
-	meta := make(message.Metadata)
+func (d DefaultMarshalerUnmarshaler) Unmarshal(msg *sqs.Message) (*message.Message, error) {
+	var payload string
+	if msg.Body != nil {
+		payload = *msg.Body
+	}
 
-	for k, v := range attributes {
+	wmsg := message.NewMessage("", []byte(payload))
+	wmsg.Metadata = make(message.Metadata, len(msg.MessageAttributes))
+
+	for k, v := range msg.MessageAttributes {
 		if v.DataType == nil {
+			continue
+		}
+
+		if k == UUIDHeaderKey && *v.DataType == AWSStringDataType {
+			wmsg.UUID = *v.StringValue
 			continue
 		}
 
 		switch *v.DataType {
 		case AWSStringDataType, AWSNumberDataType:
 			if v.StringValue != nil {
-				meta[k] = *v.StringValue
+				wmsg.Metadata[k] = *v.StringValue
 			}
 		case AWSBinaryDataType:
-			meta[k] = string(v.BinaryValue)
+			wmsg.Metadata[k] = string(v.BinaryValue)
 		}
 	}
 
-	return meta
+	return wmsg, nil
 }
 
 const (

--- a/sqs/marshaler_test.go
+++ b/sqs/marshaler_test.go
@@ -4,19 +4,11 @@ import (
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMetadaConverter(t *testing.T) {
-	metadata := message.Metadata{
-		"name": "some-event-name",
-		"test": "other-value",
-	}
-
-	metadataOut := attributesToMetadata(metadataToAttributes(metadata))
-
-	require.Equal(t, metadata, metadataOut, "metadata after transformations should be the same")
-}
 
 func TestMarshaler(t *testing.T) {
 	msg := message.NewMessage("some-id", []byte("payload"))
@@ -29,11 +21,68 @@ func TestMarshaler(t *testing.T) {
 
 	awsMsg, err := dum.Marshal(msg)
 	require.NoError(t, err)
+	assert.Equal(t, &sqs.Message{
+		Body: aws.String("payload"),
+		MessageAttributes: map[string]*sqs.MessageAttributeValue{
+			"_watermill_message_uuid": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("some-id"),
+			},
+			"name": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("some-event-name"),
+			},
+			"test": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("other-value"),
+			},
+		},
+	}, awsMsg)
+}
 
-	msgOut, err := dum.Unmarshal(awsMsg)
+func TestUnmarshaler(t *testing.T) {
+	m := &DefaultMarshalerUnmarshaler{}
+
+	msg, err := m.Unmarshal(&sqs.Message{
+		Body: aws.String("payload"),
+		MessageAttributes: map[string]*sqs.MessageAttributeValue{
+			"_watermill_message_uuid": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("some-id"),
+			},
+			"name": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("some-event-name"),
+			},
+			"test": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: aws.String("other-value"),
+			},
+			"nil datatype": {
+				DataType:    nil,
+				StringValue: nil,
+			},
+			"nil stringvalue": {
+				DataType:    aws.String(AWSStringDataType),
+				StringValue: nil,
+			},
+			"numeric": {
+				DataType:    aws.String(AWSNumberDataType),
+				StringValue: aws.String("1234"),
+			},
+			"binary": {
+				DataType:    aws.String(AWSBinaryDataType),
+				BinaryValue: []byte("binary-data"),
+			},
+		},
+	})
 	require.NoError(t, err)
-
-	require.Equal(t, msg.UUID, msgOut.UUID)
-	require.Equal(t, msg.Payload, msgOut.Payload)
-	require.Equal(t, msg.Metadata, msgOut.Metadata)
+	assert.Equal(t, "some-id", msg.UUID)
+	assert.Equal(t, message.Payload("payload"), msg.Payload)
+	assert.Equal(t, message.Metadata{
+		"name":    "some-event-name",
+		"test":    "other-value",
+		"numeric": "1234",
+		"binary":  "binary-data",
+	}, msg.Metadata)
 }


### PR DESCRIPTION
The watermill message UUID was lost during publishing & subscribing to the message, because sqs.Message's `MessageId` should signify the Amazon message ID, not the watermill message UUID.

Use the metadata to store the UUID under the key `_watermill_message_uuid`.

Minor simplifications/pre-allocations of data for performance.